### PR TITLE
Adds flags to setup() to allow sphinx to read and write in parallel.

### DIFF
--- a/cartouche/sphinxext.py
+++ b/cartouche/sphinxext.py
@@ -1,4 +1,5 @@
 from .parser import (rewrite_autodoc, builder_inited)
+from .version import (__version__)
 
 __author__ = 'Robert Smallshire'
 
@@ -9,3 +10,9 @@ def setup(app):
     app.add_config_value('cartouche_accept_bulleted_raises', False, 'env')
     app.connect('builder-inited', builder_inited)
     app.connect('autodoc-process-docstring', rewrite_autodoc)
+
+    return dict(
+        version = __version__,
+        parallel_read_safe = True,
+        parallel_write_safe = True
+    )


### PR DESCRIPTION
Sphinx 1.5+ requires a few flags to be set to allow parallel reading and writing. This has a significant effect on overall build time.